### PR TITLE
Amended a minor assignment problem

### DIFF
--- a/gdc-tsv-tool.py
+++ b/gdc-tsv-tool.py
@@ -153,13 +153,13 @@ def retrieve_metadata_for_list(file_list):
                   "cases.samples.portions.slides," \
                   "analysis.metadata.read_groups"
 
-        params = {"filters":
-                 {"op":"in","content":
-                 {"field":"file_id", "value":file_list}},
-                  "format":"TSV",
-                  "size": "10000",
-                  "fields":fields,
-                  "expand":expand}
+    params = {"filters":
+             {"op":"in","content":
+             {"field":"file_id", "value":file_list}},
+              "format":"TSV",
+              "size": "10000",
+              "fields":fields,
+              "expand":expand}
     response = requests.post(url,
                              data = json.dumps(params),
                              headers = headers,


### PR DESCRIPTION
While choosing the --clinical or --simple option, the variable "params" won't be assigned, causing "UnboundLocalError: local variable 'params' referenced before assignment" error. Amended this problem by changing indents.
![批注 2019-10-08 204556](https://user-images.githubusercontent.com/42372025/66396601-a88f9500-ea0c-11e9-84b5-b5bd8fb8fdf3.png)

